### PR TITLE
Added a simple lexer.

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -1,5 +1,7 @@
 package main
 
+import "strings"
+
 // These constants are our token-types
 const (
 	EOF = "EOF"
@@ -49,6 +51,11 @@ func NewLexer(input string) *Lexer {
 
 	// Create the lexer object.
 	l := &Lexer{input: input}
+
+	// Strip newlines/spaces from our iput
+	l.input = strings.ReplaceAll(l.input, "\n", "")
+	l.input = strings.ReplaceAll(l.input, "\r", "")
+	l.input = strings.ReplaceAll(l.input, " ", "")
 
 	// Populate the simple token-types in a map for
 	// later use.

--- a/lexer.go
+++ b/lexer.go
@@ -93,7 +93,7 @@ func (l *Lexer) Next() *Token {
 			//
 			// Some tokens can't repeat.  Horrid.
 			//
-			if char == LOOP_OPEN || char == LOOP_CLOSE {
+			if char == INPUT || char == OUTPUT || char == LOOP_OPEN || char == LOOP_CLOSE {
 				l.position++
 				return &Token{Type: char, Repeat: 1}
 			}

--- a/lexer.go
+++ b/lexer.go
@@ -1,0 +1,114 @@
+package main
+
+// These constants are our token-types
+const (
+	EOF = "EOF"
+
+	LESS       = "<"
+	GREATER    = ">"
+	PLUS       = "+"
+	MINUS      = "-"
+	OUTPUT     = "."
+	INPUT      = ","
+	LOOP_OPEN  = "["
+	LOOP_CLOSE = "]"
+)
+
+// Token contains the next token from the input program.
+type Token struct {
+
+	// Type contains the token-type (such as "<", "[", etc).
+	Type string
+
+	// Repeat contains the number of consecutive appearances we've seen
+	// of this token.
+	Repeat int
+}
+
+// Lexer holds our lexer state.
+type Lexer struct {
+
+	// input is the string we're lexing.
+	input string
+
+	// position is the current position within the input-string.
+	position int
+
+	// simple map of single-character tokens to their type
+	known map[string]string
+}
+
+// NewLexer creates a new Lexer, which will parse the specified
+// input program into a series of tokens.
+func NewLexer(input string) *Lexer {
+
+	// Create the lexer object.
+	l := &Lexer{input: input}
+
+	// Populate the simple token-types in a map for
+	// later use.
+	l.known = make(map[string]string)
+
+	l.known["+"] = PLUS
+	l.known["-"] = MINUS
+	l.known[">"] = GREATER
+	l.known["<"] = LESS
+	l.known[","] = INPUT
+	l.known["."] = OUTPUT
+	l.known["["] = LOOP_OPEN
+	l.known["]"] = LOOP_CLOSE
+
+	return l
+}
+
+// Next returns the next token from our input stream.
+//
+// This is pretty naive lexer because we only have to consider
+// single-character tokens.  However we do look for tokens which
+// are repeated.
+func (l *Lexer) Next() *Token {
+
+	// Loop until we've exhausted our input.
+	for l.position < len(l.input) {
+
+		// Get the next character
+		char := string(l.input[l.position])
+
+		// Is this a known character/token?
+		_, ok := l.known[char]
+		if ok {
+
+			// OK record our starting position
+			begin := l.position
+
+			// Loop forward to see if that character
+			// is repeated further times
+			for l.position < len(l.input) {
+
+				// If it isn't the same character
+				// we're done
+				if string(l.input[l.position]) != char {
+					break
+				}
+
+				// Otherwise keep advancing forward
+				l.position++
+			}
+
+			// Return the token and the times it was
+			// seen in adjacent positions
+			count := l.position - begin
+			return &Token{Type: char, Repeat: count}
+		}
+
+		//
+		// Here we're ignoring a token which was unknown.
+		//
+	}
+
+	//
+	// If we got here then we're at/after the end of our input
+	// string.  So we just return EOF.
+	//
+	return &Token{Type: EOF, Repeat: 1}
+}

--- a/lexer.go
+++ b/lexer.go
@@ -4,6 +4,11 @@ package main
 const (
 	EOF = "EOF"
 
+	//
+	// TODO: Better names.
+	//
+	// Are there standard values?
+	//
 	LESS       = "<"
 	GREATER    = ">"
 	PLUS       = "+"
@@ -78,6 +83,14 @@ func (l *Lexer) Next() *Token {
 		_, ok := l.known[char]
 		if ok {
 
+			//
+			// Some tokens can't repeat.  Horrid.
+			//
+			if char == LOOP_OPEN || char == LOOP_CLOSE {
+				l.position++
+				return &Token{Type: char, Repeat: 1}
+			}
+
 			// OK record our starting position
 			begin := l.position
 
@@ -104,6 +117,7 @@ func (l *Lexer) Next() *Token {
 		//
 		// Here we're ignoring a token which was unknown.
 		//
+		l.position++
 	}
 
 	//

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestLexer(t *testing.T) {
+
+	tests := []struct {
+		expectedType  string
+		expectedCount int
+	}{
+		{PLUS, 1},
+		{MINUS, 1},
+		{LESS, 5},
+		{GREATER, 5},
+		{LOOP_OPEN, 1},
+		{LOOP_CLOSE, 1},
+		{OUTPUT, 1},
+		{INPUT, 1},
+		{EOF, 1},
+	}
+
+	l := NewLexer("+-<<<<<>>>>>[].,")
+
+	for i, tt := range tests {
+		tok := l.Next()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+		}
+		if tok.Repeat != tt.expectedCount {
+			t.Fatalf("tests[%d] - count wrong, expected=%d, got=%d", i, tt.expectedCount, tok.Repeat)
+		}
+	}
+
+}

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -21,7 +21,7 @@ func TestLexer(t *testing.T) {
 		{EOF, 1},
 	}
 
-	l := NewLexer("+-<<<<<>>>>>[].,")
+	l := NewLexer("+-<<<<<\n>>>>>[].,")
 
 	for i, tt := range tests {
 		tok := l.Next()

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 )
 
+// TestLexer performs a trivial test of the lexer
 func TestLexer(t *testing.T) {
 
 	tests := []struct {
@@ -32,5 +33,30 @@ func TestLexer(t *testing.T) {
 			t.Fatalf("tests[%d] - count wrong, expected=%d, got=%d", i, tt.expectedCount, tok.Repeat)
 		}
 	}
+}
 
+// TestAdjacent is designed to ensure we count adjacent runs of characters
+// even when newlines are in the way.
+func TestAdjacent(t *testing.T) {
+
+	tests := []struct {
+		expectedType  string
+		expectedCount int
+	}{
+		{PLUS, 5},
+		{MINUS, 5},
+		{EOF, 1},
+	}
+
+	l := NewLexer("+\n+\n+\n+\n+- - - - -")
+
+	for i, tt := range tests {
+		tok := l.Next()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+		}
+		if tok.Repeat != tt.expectedCount {
+			t.Fatalf("tests[%d] - count wrong, expected=%d, got=%d", i, tt.expectedCount, tok.Repeat)
+		}
+	}
 }


### PR DESCRIPTION
This pull-request, once complete, will replace our inline parsing with a standalone brainfuck lexer.

The lexer will produce a stream of tokens, along with a count of how many times those tokens were seen repeated.

So given an input string of "`<<<<<>>>>>`" we'll expect to see:

* `{Type: "<", Repeat: 5}`
* `{Type: ">", Repeat: 5}`
* `{Type: EOF, Repeat: 1}`

Trivial cases added too, but not exhaustively.   This will close #3.