### PR TITLE
13 optimize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,8 @@ test-implementation:
 		diff examples/$${nm}.out x || ( echo "Example failed: $$i"; exit 1 ) ;\
 		echo "OK" ; \
 	done
+
+time:
+	make
+	./bfcc -backend=asm examples/mandelbrot.bf ; bash -c "time ./a.out" >/dev/null
+	./bfcc -backend=c   examples/mandelbrot.bf ; bash -c "time ./a.out" >/dev/null

--- a/generators/asm.go
+++ b/generators/asm.go
@@ -120,6 +120,36 @@ _start:
 		case lexer.LOOP_OPEN:
 
 			//
+			// We sneekily optimize "[-]" by converting it
+			// into "move register, 0"
+			//
+			// Since this involves looking at future-tokens
+			// we need to make sure we're not at the end of
+			// the program.
+			//
+			if offset+2 < len(program) {
+
+				//
+				// Look for the next two tokens "-]", if
+				// we find them then we're looking at "[-]"
+				// which is something we can optimize.
+				//
+				if program[offset+1].Type == lexer.DEC_CELL &&
+					program[offset+2].Type == lexer.LOOP_CLOSE {
+					// register == zero
+					buff.WriteString("  mov byte ptr [%r8], 0\n\n")
+
+					// 1. Skip this instruction,
+					// 2. the next one "-"
+					// 3. and the final one "]"
+					offset += 3
+
+					// And continue the loop again.
+					continue
+				}
+			}
+
+			//
 			// Open of a block.
 			//
 			// If the index-value is zero then jump to the

--- a/generators/asm.go
+++ b/generators/asm.go
@@ -72,9 +72,9 @@ _start:
 	l := lexer.New(g.input)
 
 	//
-	// Loop forever, processing the next token
+	// Program consists of all tokens
 	//
-	tok := l.Next()
+	program := l.Tokens()
 
 	//
 	// We keep track of the loop-labels here.
@@ -88,7 +88,13 @@ _start:
 	// We'll process the complete program until
 	// we hit an end of file/input
 	//
-	for tok.Type != lexer.EOF {
+	offset := 0
+	for offset < len(program) {
+
+		//
+		// The current token
+		//
+		tok := program[offset]
 
 		//
 		// Output different things depending on the token-type
@@ -187,7 +193,7 @@ _start:
 		//
 		// Keep processing
 		//
-		tok = l.Next()
+		offset++
 	}
 
 	// terminate

--- a/generators/c.go
+++ b/generators/c.go
@@ -43,15 +43,21 @@ int main (int arc, char *argv[]) {
 	l := lexer.New(c.input)
 
 	//
-	// Loop forever, processing the next token
+	// Program consists of all tokens
 	//
-	tok := l.Next()
+	program := l.Tokens()
 
 	//
 	// We'll process the complete program until
 	// we hit an end of file/input
 	//
-	for tok.Type != lexer.EOF {
+	offset := 0
+	for offset < len(program) {
+
+		//
+		// The current token
+		//
+		tok := program[offset]
 
 		//
 		// Output different things depending on the token-type
@@ -86,7 +92,7 @@ int main (int arc, char *argv[]) {
 		//
 		// Keep processing
 		//
-		tok = l.Next()
+		offset++
 	}
 
 	// Close the main-function

--- a/generators/c.go
+++ b/generators/c.go
@@ -79,6 +79,38 @@ int main (int arc, char *argv[]) {
 			buff.WriteString("  array[idx] = getchar();\n")
 
 		case lexer.LOOP_OPEN:
+
+			//
+			// We sneekily optimize "[-]" by converting it
+			// into an explicit setting of the cell-content
+			// to zero.
+			//
+			// Since this involves looking at future-tokens
+			// we need to make sure we're not at the end of
+			// the program.
+			//
+			if offset+2 < len(program) {
+
+				//
+				// Look for the next two tokens "-]", if
+				// we find them then we're looking at "[-]"
+				// which is something we can optimize.
+				//
+				if program[offset+1].Type == lexer.DEC_CELL &&
+					program[offset+2].Type == lexer.LOOP_CLOSE {
+					// register == zero
+					buff.WriteString("  array[idx] = 0;\n")
+
+					// 1. Skip this instruction,
+					// 2. the next one "-"
+					// 3. and the final one "]"
+					offset += 3
+
+					// And continue the loop again.
+					continue
+				}
+			}
+
 			buff.WriteString("  while (array[idx]) {\n")
 
 		case lexer.LOOP_CLOSE:

--- a/generators/interpreter.go
+++ b/generators/interpreter.go
@@ -148,7 +148,7 @@ func (i *Interpreter) evaluate() error {
 		i.memory[i.ptr] = int(buf[0])
 
 	case lexer.OUTPUT:
-		fmt.Printf("%s", string(i.memory[i.ptr]))
+		fmt.Printf("%c", rune(i.memory[i.ptr]))
 
 	}
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -91,6 +91,20 @@ func New(input string) *Lexer {
 	return l
 }
 
+// Tokens returns ALL tokens from the input-stream.
+func (l *Lexer) Tokens() []*Token {
+	var res []*Token
+
+	tok := l.Next()
+
+	for tok.Type != EOF {
+		res = append(res, tok)
+		tok = l.Next()
+	}
+
+	return res
+}
+
 // Next returns the next token from our input stream.
 //
 // This is pretty naive lexer because we only have to consider


### PR DESCRIPTION
This pull-request will close #13, by implementing the most basic optimization as read in the linked article - converting the specific input string `[-]` into an optimized version of the same thing.

* Updated lexer to get a stream of tokens all at once
  * So we can "peek ahead" without worrying about unwinding if we didn't find what we expected.
  * This is impossible/hard with the `tok := l.Next()` approach.
* Updated the `asm` and `c` backends to use this new API.
* Actually implement the optimization in both backends.
